### PR TITLE
Update _team.scss

### DIFF
--- a/themes/coderdojoschoeneweide/assets/scss/components/_team.scss
+++ b/themes/coderdojoschoeneweide/assets/scss/components/_team.scss
@@ -114,10 +114,6 @@
         border-bottom: 4px solid transparent;
         transform: translate3d(2px, 3px, 0);
       }
-
-      &:hover {
-        cursor: pointer;
-      }
     }
   }
 }


### PR DESCRIPTION
Hier wird der Hover-effekt entfernt. Bei manchen Team-Kacheln gab es ihn noch, obwohl es keine Rückseite mehr gab.