### PR TITLE
Simplify filter

### DIFF
--- a/content/dojo-projects/finde_mich.md
+++ b/content/dojo-projects/finde_mich.md
@@ -1,6 +1,6 @@
 ---
 title: "Finde mich von Ottikar"
-date: 2023-26-07T19:08:24+02:00
+date: 2023-07-26T19:08:24+02:00
 projectLink: "https://scratch.mit.edu/projects/846766369"
 ---
 

--- a/themes/coderdojoschoeneweide/assets/scss/layout/_main.scss
+++ b/themes/coderdojoschoeneweide/assets/scss/layout/_main.scss
@@ -68,7 +68,6 @@ main {
     }
   }
 
-  #filter-blogs,
   #filter {
     border: 1px solid $color-dark;
     @include theme() {
@@ -235,7 +234,6 @@ main {
       }
     }
 
-    #filter-blogs,
     #filter {
       &.show {
         max-height: 70rem;

--- a/themes/coderdojoschoeneweide/assets/scss/layout/_main.scss
+++ b/themes/coderdojoschoeneweide/assets/scss/layout/_main.scss
@@ -53,16 +53,19 @@ main {
         max-width: 100%;
       }
     }
+
     .blog-image-title {
       text-align: center;
     }
   }
+
   a:visited {
     @include theme() {
       color: theme-get("visited-link-color");
     }
   }
-  a:link {
+
+  a {
     @include theme() {
       color: theme-get("not-visited-link-color");
     }
@@ -109,13 +112,13 @@ main {
       }
     }
 
-    .category {
+    .tags {
       margin: 0 0.5rem 0.5rem 0;
       display: inline-block;
     }
   }
 
-  #all-posts {
+  #all-posts, .all-workshops {
     h2 {
       text-align: center;
     }

--- a/themes/coderdojoschoeneweide/layouts/_default/list.html
+++ b/themes/coderdojoschoeneweide/layouts/_default/list.html
@@ -45,7 +45,8 @@
     </div>
     <ul id="results" class="post-list">
         {{ range .Pages }}
-        <li data-readingtime="{{ .ReadingTime }}" data-tags="{{ .Params.tags }}" data-title="{{ .Title }}">
+        <li id="result-item" data-readingtime="{{ .ReadingTime }}" data-tags="{{ .Params.tags }}"
+            data-title="{{ .Title }}">
             <a href="{{ .Permalink }}">
                 <h3>{{ .Date.Format "02.01.2006" }} | {{ .Title }}</h3>
                 <p>Lesedauer: ca. {{ .ReadingTime }} Minute{{ if ne .ReadingTime 1 }}n{{ end }}</p>

--- a/themes/coderdojoschoeneweide/layouts/_default/list.html
+++ b/themes/coderdojoschoeneweide/layouts/_default/list.html
@@ -13,8 +13,6 @@
     {{ end }}
     {{ end }}
     {{ end }}
-    {{$tags = sort $tags}}
-    {{$readingTime = sort $readingTime}}
     <a href="#" id="filter-toggle">Filter <span>▸</span></a>
     <div id="filter">
         <label for="title-search-filter">
@@ -22,20 +20,20 @@
             <input type="search" id="title-search-filter" name="search-title" placeholder="Titel des Blogs"
                    spellcheck="true"/>
         </label>
-        <label for="readingTime-filters">
+        <label for="reading-time-filter">
             <span>Lesedauer:</span>
-            <select id="readingTime-filters">
+            <select id="reading-time-filter">
                 <option value="">Alle</option>
-                {{ range $readingTime }}
+                {{ range sort $readingTime }}
                 <option value="{{ . }}">{{ . }}min</option>
                 {{ end }}
             </select>
         </label>
         <label>
-            <span>Kategorien:</span>
+            <span>Tags:</span>
             <div id="tag-filters">
-                {{ range $tags }}
-                <label class="category">
+                {{ range sort $tags }}
+                <label class="tags">
                     <input type="checkbox" value="{{ . }}">
                     #{{ . }}
                 </label>

--- a/themes/coderdojoschoeneweide/layouts/_default/list.html
+++ b/themes/coderdojoschoeneweide/layouts/_default/list.html
@@ -16,7 +16,7 @@
     {{$tags = sort $tags}}
     {{$readingTime = sort $readingTime}}
     <a href="#" id="filter-toggle">Filter <span>▸</span></a>
-    <div id="filter-blogs">
+    <div id="filter">
         <label for="title-search-filter">
             <span>Suche:</span>
             <input type="search" id="title-search-filter" name="search-title" placeholder="Titel des Blogs"
@@ -43,7 +43,7 @@
             </div>
         </label>
     </div>
-    <ul id="results-blogs" class="post-list">
+    <ul id="results" class="post-list">
         {{ range .Pages }}
         <li data-readingtime="{{ .ReadingTime }}" data-tags="{{ .Params.tags }}" data-title="{{ .Title }}">
             <a href="{{ .Permalink }}">

--- a/themes/coderdojoschoeneweide/layouts/workshops/list.html
+++ b/themes/coderdojoschoeneweide/layouts/workshops/list.html
@@ -23,7 +23,7 @@
             <span>Alter:</span>
             <select id="age-filter">
                 <option value="">Alle</option>
-                {{ range $ages }}
+                {{ range sort $ages }}
                 <option value="{{ . }}">{{ . }}</option>
                 {{ end }}
             </select>
@@ -32,16 +32,16 @@
             <span>Dauer:</span>
             <select id="duration-filter">
                 <option value="">Alle</option>
-                {{ range $durations }}
+                {{ range sort $durations }}
                 <option value="{{ . }}">{{ . }}</option>
                 {{ end }}
             </select>
         </label>
         <label>
-            <span>Kategorien:</span>
+            <span>Tags:</span>
             <div id="tag-filters">
-                {{ range $tags }}
-                <label class="category">
+                {{ range sort $tags }}
+                <label class="tags">
                     <input type="checkbox" value="{{ . }}">
                     #{{ . }}
                 </label>
@@ -54,7 +54,8 @@
         <li id="result-item" data-age="{{ .Params.age }}" data-duration="{{ .Params.duration }}"
             data-tags="{{ .Params.tags }}">
             <a href="{{ .RelPermalink }}">
-                <img src="{{ if .Params.image }}{{ (.Page.Resources.GetMatch .Params.image).RelPermalink }}{{ else }}{{ .Site.BaseURL }}images/placeholder.svg{{ end }}" alt="workshop thumbnail">
+                <img src="{{ if .Params.image }}{{ (.Page.Resources.GetMatch .Params.image).RelPermalink }}{{ else }}{{ .Site.BaseURL }}images/placeholder.svg{{ end }}"
+                     alt="workshop thumbnail">
                 <div class="card-properties">
                     <h3>{{ .Title }}</h3>
                     {{ partial "workshop-properties.html" . }}

--- a/themes/coderdojoschoeneweide/layouts/workshops/list.html
+++ b/themes/coderdojoschoeneweide/layouts/workshops/list.html
@@ -51,7 +51,8 @@
     </div>
     <ul id="results">
         {{ range .Pages }}
-        <li data-age="{{ .Params.age }}" data-duration="{{ .Params.duration }}" data-tags="{{ .Params.tags }}">
+        <li id="result-item" data-age="{{ .Params.age }}" data-duration="{{ .Params.duration }}"
+            data-tags="{{ .Params.tags }}">
             <a href="{{ .RelPermalink }}">
                 <img src="{{ if .Params.image }}{{ (.Page.Resources.GetMatch .Params.image).RelPermalink }}{{ else }}{{ .Site.BaseURL }}images/placeholder.svg{{ end }}" alt="workshop thumbnail">
                 <div class="card-properties">

--- a/themes/coderdojoschoeneweide/static/js/filters.js
+++ b/themes/coderdojoschoeneweide/static/js/filters.js
@@ -21,8 +21,9 @@ document.addEventListener("DOMContentLoaded", () => {
 
     const filters = new Map();
     //Mapping -> Filter , [selector (html element id), html element]
-    //Filter blogs
+    //Filter blogs + workshop
     filters.set(tagFilters, ["#tag-filters input", "checkbox"]);
+    //Filter blogs
     filters.set(titleFilter, ["#title-search-filter", "input"]);
     filters.set(readingFilter, ["#readingTime-filters", "select"]);
     //Filter workshop
@@ -75,11 +76,9 @@ function addEventListenerToFilter(filters) {
                     if (value != null) {
                         filterName.push(value.toLowerCase());
                     }
-
                     updateFilterResults();
                 });
             }
-
         } catch (e) {
             // adding an eventListener can cause an error if selector does not exist
             // Some of the filters don't exist on the other pages

--- a/themes/coderdojoschoeneweide/static/js/filters.js
+++ b/themes/coderdojoschoeneweide/static/js/filters.js
@@ -52,25 +52,6 @@ document.addEventListener("DOMContentLoaded", () => {
 
     filterToggle.addEventListener("click", toggleFilter(filterSection, filterArrow));
 
-    try {
-        //for branch redesign!
-        document.querySelectorAll("#btn-tag-filters button").forEach(button => button.addEventListener("click", evt => {
-            //check if tag already in tagFilters
-            if (tagFilters.findIndex(item => item === evt.target.value) === -1) {
-                tagFilters.push(evt.target.value);
-                //check the tag in the filter-checkbox
-                filterSection.querySelectorAll("#tag-filters input").forEach(checkbox => {
-                    if (checkbox.value === evt.target.value) {
-                        checkbox.checked = true;
-                    }
-                })
-                updateFilterResults();
-            }
-        }))
-    } catch (e) {
-
-    }
-
     for (const filter in filters) {
         addEventListenerToFilter(filterSection, filters[filter]);
     }

--- a/themes/coderdojoschoeneweide/static/js/filters.js
+++ b/themes/coderdojoschoeneweide/static/js/filters.js
@@ -17,7 +17,28 @@ document.addEventListener("DOMContentLoaded", () => {
 
     const filterToggle = document.querySelector("#filter-toggle");
     filterArrow = filterToggle.querySelector("span");
-    filterToggle.addEventListener("click", toggleFilter);
+
+
+    try {
+        filterToggle.addEventListener("click", toggleFilter);
+
+        //for branch redesign!
+        document.querySelectorAll("#btn-tag-filters button").forEach(button => button.addEventListener("click", evt => {
+            //check if tag already in tagFilters
+            if (tagFilters.findIndex(item => item === evt.target.value) === -1) {
+                tagFilters.push(evt.target.value);
+                //check the tag in the filter-checkbox
+                filter.querySelectorAll("#tag-filters input").forEach(checkbox => {
+                    if (checkbox.value === evt.target.value) {
+                        checkbox.checked = true;
+                    }
+                })
+                updateFilterResults();
+            }
+        }))
+    } catch (e) {
+
+    }
 
     const filters = new Map();
     //Mapping -> Filter , [selector (html element id), html element]

--- a/themes/coderdojoschoeneweide/static/js/filters.js
+++ b/themes/coderdojoschoeneweide/static/js/filters.js
@@ -1,111 +1,89 @@
 let showFilter = false;
 let filterArrow;
-let filterWorkshop;
-let filterBlog;
-let resultsBlog;
+let filter;
 let results;
+let section_blogs;
 
 let ageFilter = null;
 let durationFilter = null;
 let readingFilter = null;
 let titleFilter = null;
-let tagBlogFilters = [];
 let tagFilters = [];
 
 document.addEventListener("DOMContentLoaded", () => {
-    filterWorkshop = document.querySelector("#filter");
-    filterBlog = document.querySelector("#filter-blogs");
+    section_blogs = document.querySelector("#all-posts");
+    filter = document.querySelector("#filter");
     results = document.querySelectorAll("#results li");
-    resultsBlog = document.querySelectorAll("#results-blogs li");
 
-    if (filterWorkshop != null) {
-        const filterToggle = document.querySelector("#filter-toggle");
-        filterArrow = filterToggle.querySelector("span");
-        filterToggle.addEventListener("click", toggleFilterWorkshop);
+    const filterToggle = document.querySelector("#filter-toggle");
+    filterArrow = filterToggle.querySelector("span");
+    filterToggle.addEventListener("click", toggleFilter);
 
-        filterWorkshop.querySelector("#age-filter").addEventListener("change", event => {
-            ageFilter = event.target.value !== "" ? event.target.value : null;
-            updateFilterWorkshopResults();
-        });
-        filterWorkshop.querySelector("#duration-filter").addEventListener("change", event => {
-            durationFilter = event.target.value !== "" ? event.target.value : null;
-            updateFilterWorkshopResults();
-        });
-        filterWorkshop.querySelectorAll("#tag-filters input")
-            .forEach(checkbox => checkbox.addEventListener("change", event => {
-                if (event.target.checked)
-                    tagFilters.push(event.target.value);
-                else
-                    tagFilters.splice(tagFilters.indexOf(event.target.value), 1);
-                updateFilterWorkshopResults();
-            }));
-    }
-
-    if (filterBlog != null) {
-        const filterToggle = document.querySelector("#filter-toggle");
-        filterArrow = filterToggle.querySelector("span");
-        filterToggle.addEventListener("click", toggleFilterBlog);
-
-        filterBlog.querySelectorAll("#tag-filters input").forEach(checkbox => checkbox.addEventListener("change", event => {
+    //Filter workshop + blogs
+    filter.querySelectorAll("#tag-filters input")
+        .forEach(checkbox => checkbox.addEventListener("change", event => {
             if (event.target.checked)
-                tagBlogFilters.push(event.target.value);
+                tagFilters.push(event.target.value);
             else
-                tagBlogFilters.splice(tagBlogFilters.indexOf(event.target.value), 1);
-            updateFilterBlogResults();
+                tagFilters.splice(tagFilters.indexOf(event.target.value), 1);
+            updateFilterResults();
         }));
 
-        filterBlog.querySelector("#title-search-filter").addEventListener("input", event => {
+    if (section_blogs != null) {
+        //Filter blogs
+        filter.querySelector("#title-search-filter").addEventListener("input", event => {
             titleFilter = event.target.value !== "" ? event.target.value : null;
             if (titleFilter != null) {
                 titleFilter = titleFilter.toLowerCase();
             }
-            updateFilterBlogResults();
+            updateFilterResults();
         });
 
-        filterBlog.querySelector("#readingTime-filters").addEventListener("change", event => {
+        //Filter blogs
+        filter.querySelector("#readingTime-filters").addEventListener("change", event => {
             readingFilter = event.target.value !== "" ? event.target.value : null;
-            updateFilterBlogResults();
+            updateFilterResults();
+        });
+    } else {
+
+        //Filter workshop
+        filter.querySelector("#age-filter").addEventListener("change", event => {
+            ageFilter = event.target.value !== "" ? event.target.value : null;
+            updateFilterResults();
+        });
+
+        //Filter workshop
+        filter.querySelector("#duration-filter").addEventListener("change", event => {
+            durationFilter = event.target.value !== "" ? event.target.value : null;
+            updateFilterResults();
         });
     }
 });
 
-function toggleFilterWorkshop(event) {
+function toggleFilter(event) {
     event.preventDefault();
     showFilter = !showFilter;
     if (showFilter) {
         filterArrow.innerText = "▾";
-        filterWorkshop.classList.add("show");
+        filter.classList.add("show");
     } else {
         filterArrow.innerText = "▸";
-        filterWorkshop.classList.remove("show");
+        filter.classList.remove("show");
     }
 }
 
-function toggleFilterBlog(event) {
-    event.preventDefault();
-    showFilter = !showFilter;
-    if (showFilter) {
-        filterArrow.innerText = "▾";
-        filterBlog.classList.add("show");
+function updateFilterResults() {
+    if (section_blogs != null) {
+        results.forEach(blog => {
+            blog.hidden = !((!readingFilter || blog.dataset.readingtime === readingFilter) &&
+                (!titleFilter || blog.dataset.title.toLowerCase().includes(titleFilter) === true) &&
+                (tagFilters.length === 0 || tagFilters.every(c => blog.dataset.tags.indexOf(c) >= 0)));
+        });
     } else {
-        filterArrow.innerText = "▸";
-        filterBlog.classList.remove("show");
+        results.forEach(workshop => {
+            workshop.hidden = !((!ageFilter || workshop.dataset.age === ageFilter) &&
+                (!durationFilter || workshop.dataset.duration === durationFilter) &&
+                (tagFilters.length === 0 || tagFilters.every(c => workshop.dataset.tags.indexOf(c) >= 0)));
+        });
     }
-}
-
-function updateFilterBlogResults() {
-    resultsBlog.forEach(blog => {
-        blog.hidden = !((!readingFilter || blog.dataset.readingtime === readingFilter) &&
-            (!titleFilter || blog.dataset.title.toLowerCase().includes(titleFilter) === true) &&
-            (tagBlogFilters.length === 0 || tagBlogFilters.every(c => blog.dataset.tags.indexOf(c) >= 0)));
-    });
-}
-
-function updateFilterWorkshopResults() {
-    console.log(ageFilter);
-    results.forEach(workshop => {
-        workshop.hidden = !((!ageFilter || workshop.dataset.age === ageFilter) &&
-            (!durationFilter || workshop.dataset.duration === durationFilter) &&
-            (tagFilters.length === 0 || tagFilters.every(c => workshop.dataset.tags.indexOf(c) >= 0)));
-    });
 }

--- a/themes/coderdojoschoeneweide/static/js/filters.js
+++ b/themes/coderdojoschoeneweide/static/js/filters.js
@@ -1,34 +1,65 @@
-let showFilter = false;
-let filterArrow;
-let filter;
 let results;
 let section_blogs;
 
-let ageFilter = [];
-let durationFilter = [];
-let readingFilter = [];
-let titleFilter = [];
-let tagFilters = [];
+/**
+ * Definitions for all possible filters
+ * @type {Record<string, {value: any, selector: string, type: string, check: (value: any) => boolean}>}
+ */
+const filters = {
+    age: {
+        value: "",
+        selector: "#age-filter",
+        type: "select",
+        check: (value) => filters.age.value.length === 0 || value.toLowerCase() === filters.age.value
+    },
+    duration: {
+        value: "",
+        selector: "#duration-filter",
+        type: "select",
+        check: (value) => filters.duration.value.length === 0 || value.toLowerCase() === filters.duration.value
+    },
+    readingTime: {
+        value: "",
+        selector: "#reading-time-filter",
+        type: "select",
+        check: (value) => filters.readingTime.value.length === 0 || value.toLowerCase() === filters.readingTime.value
+    },
+    title: {
+        value: "",
+        selector: "#title-search-filter",
+        type: "input",
+        check: (value) => filters.title.value.length === 0 || value.toLowerCase().includes(filters.title.value)
+    },
+    tag: {
+        value: [],
+        selector: "#tag-filters input",
+        type: "checkbox",
+        check: (value) => filters.tag.value.length === 0 || filters.tag.value.every(x => value.includes(x))
+    }
+};
 
 document.addEventListener("DOMContentLoaded", () => {
+    const filterSection = document.querySelector("#filter");
+    // Abort this script if there are no filters on this page
+    if (!filterSection) return;
+
+
     section_blogs = document.querySelector("#all-posts");
-    filter = document.querySelector("#filter");
     results = document.querySelectorAll("#results #result-item");
 
     const filterToggle = document.querySelector("#filter-toggle");
-    filterArrow = filterToggle.querySelector("span");
+    const filterArrow = filterToggle.querySelector("span");
 
+    filterToggle.addEventListener("click", toggleFilter(filterSection, filterArrow));
 
     try {
-        filterToggle.addEventListener("click", toggleFilter);
-
         //for branch redesign!
         document.querySelectorAll("#btn-tag-filters button").forEach(button => button.addEventListener("click", evt => {
             //check if tag already in tagFilters
             if (tagFilters.findIndex(item => item === evt.target.value) === -1) {
                 tagFilters.push(evt.target.value);
                 //check the tag in the filter-checkbox
-                filter.querySelectorAll("#tag-filters input").forEach(checkbox => {
+                filterSection.querySelectorAll("#tag-filters input").forEach(checkbox => {
                     if (checkbox.value === evt.target.value) {
                         checkbox.checked = true;
                     }
@@ -40,86 +71,76 @@ document.addEventListener("DOMContentLoaded", () => {
 
     }
 
-    const filters = new Map();
-    //Mapping -> Filter , [selector (html element id), html element]
-    //Filter blogs + workshop
-    filters.set(tagFilters, ["#tag-filters input", "checkbox"]);
-    //Filter blogs
-    filters.set(titleFilter, ["#title-search-filter", "input"]);
-    filters.set(readingFilter, ["#readingTime-filters", "select"]);
-    //Filter workshop
-    filters.set(ageFilter, ["#age-filter", "select"]);
-    filters.set(durationFilter, ["#duration-filter", "select"]);
-
-    addEventListenerToFilter(filters);
+    for (const filter in filters) {
+        addEventListenerToFilter(filterSection, filters[filter]);
+    }
 });
 
-function toggleFilter(event) {
-    event.preventDefault();
-    showFilter = !showFilter;
-    if (showFilter) {
-        filterArrow.innerText = "▾";
-        filter.classList.add("show");
-    } else {
-        filterArrow.innerText = "▸";
-        filter.classList.remove("show");
+function toggleFilter(filterSection, filterArrow) {
+    let showFilter = false;
+
+    return (event) => {
+        event.preventDefault();
+        showFilter = !showFilter;
+        if (showFilter) {
+            filterArrow.innerText = "▾";
+            filterSection.classList.add("show");
+        } else {
+            filterArrow.innerText = "▸";
+            filterSection.classList.remove("show");
+        }
     }
 }
 
-function addEventListenerToFilter(filters) {
-    filters.forEach((listElement, filterName) => {
-        try {
-            const selector = listElement[0];
-            const type = listElement[1];
+/**
+ * Add change event listener to a filter element on the current list page
+ * @param {HTMLElement} filterSection The HTML element containing all the filters
+ * @param {{value: any[], selector: string, type: string}} filter The filter object
+ */
+function addEventListenerToFilter(filterSection, filter) {
+    switch (filter.type) {
+        case "checkbox":
+            filterSection.querySelectorAll(filter.selector)
+                .forEach(checkbox => checkbox.addEventListener("change", (e) => checkboxFilterChange(e, filter)));
+            break;
+        case "input":
+            filterSection.querySelector(filter.selector)?.addEventListener("input", (e) => filterChange(e, filter));
+            break;
+        default:
+            filterSection.querySelector(filter.selector)?.addEventListener("change", (e) => filterChange(e, filter));
+            break;
+    }
+}
 
-            if (type === "checkbox") {
-                filter.querySelectorAll(selector)
-                    .forEach(checkbox => checkbox.addEventListener("change", event => {
-                        if (event.target.checked)
-                            filterName.push(event.target.value);
-                        else
-                            filterName.splice(filterName.indexOf(event.target.value), 1);
-                        updateFilterResults();
-                    }));
-            } else if (type === "input") {
-                filter.querySelector(selector).addEventListener("input", event => {
-                    const value = event.target.value !== "" ? event.target.value : null;
-                    filterName.pop();
-                    if (value != null) {
-                        filterName.push(value.toLowerCase());
-                    }
-                    updateFilterResults();
-                });
-            } else {
-                filter.querySelector(selector).addEventListener("change", event => {
-                    const value = event.target.value !== "" ? event.target.value : null;
-                    filterName.pop();
-                    if (value != null) {
-                        filterName.push(value.toLowerCase());
-                    }
-                    updateFilterResults();
-                });
-            }
-        } catch (e) {
-            // adding an eventListener can cause an error if selector does not exist
-            // Some of the filters don't exist on the other pages
-            // e.g. workshop page does not have a selector called #title-search-filter
-        }
-    })
+function checkboxFilterChange(event, filter) {
+    if (event.target.checked)
+        filter.value.push(event.target.value);
+    else
+        filter.value.splice(filter.value.indexOf(event.target.value), 1);
+    updateFilterResults();
+}
+
+function filterChange(event, filter) {
+    filter.value = event.target.value.toLowerCase();
+    updateFilterResults();
 }
 
 function updateFilterResults() {
     if (section_blogs != null) {
         results.forEach(blog => {
-            blog.hidden = !((readingFilter.length === 0 || blog.dataset.readingtime === readingFilter[0]) &&
-                (titleFilter.length === 0 || blog.dataset.title.toLowerCase().includes(titleFilter[0]) === true) &&
-                (tagFilters.length === 0 || tagFilters.every(c => blog.dataset.tags.indexOf(c) >= 0)));
+            blog.hidden = !(
+                filters.readingTime.check(blog.dataset.readingtime) &&
+                filters.title.check(blog.dataset.title) &&
+                filters.tag.check(blog.dataset.tags)
+            );
         });
     } else {
         results.forEach(workshop => {
-            workshop.hidden = !((ageFilter.length === 0 || workshop.dataset.age.toLowerCase() === ageFilter[0]) &&
-                (durationFilter.length === 0 || workshop.dataset.duration.toLowerCase() === durationFilter[0]) &&
-                (tagFilters.length === 0 || tagFilters.every(c => workshop.dataset.tags.indexOf(c) >= 0)));
+            workshop.hidden = !(
+                filters.age.check(workshop.dataset.age.toLowerCase()) &&
+                filters.duration.check(workshop.dataset.duration) &&
+                filters.tag.check(workshop.dataset.tags)
+            );
         });
     }
 }

--- a/themes/coderdojoschoeneweide/static/js/filters.js
+++ b/themes/coderdojoschoeneweide/static/js/filters.js
@@ -13,7 +13,7 @@ let tagFilters = [];
 document.addEventListener("DOMContentLoaded", () => {
     section_blogs = document.querySelector("#all-posts");
     filter = document.querySelector("#filter");
-    results = document.querySelectorAll("#results li");
+    results = document.querySelectorAll("#results #result-item");
 
     const filterToggle = document.querySelector("#filter-toggle");
     filterArrow = filterToggle.querySelector("span");


### PR DESCRIPTION
Ich hatte nochmal versucht den Filter für die Blogs und die Workshops etwas zu vereinfachen bzw. zu optimieren. Dabei bin ich zu diesem Ergebnis gekommen. 

Allgemein vielleicht eine kleine Zusammenfassung zu den Änderungen:

1.  Ich hab beiden Filter-Bereichen dieselbe id gegeben (es benötigt keine Differenzierung. Praktisch für weitere Filter in Zukunft)
2.  Alle Ergebnis-Filter sind jetzt Arrays, auch wenn manche Filter nur eine Auswahlmöglichkeit besitzen -> hängt damit zusammen, dass man am Ende in der Funktion updateFilterResults auf diese Objekte wieder zugreifen kann
3.  Eine neue Funktion geschrieben, welche im Filter-Bereich den ganzen Filtern einen EventListener hinzufügt. Hierzu wird eine Map bestehend aus der Ergebnisliste und einer Liste, welche den Selektor (Element id) und das html element bspw. "checkbox" besitzt , an die Funktion übergeben. -> Je nach html-element unterscheidet sich die Implemntierung zum Hinzufügen des EventListeners
4. Für die Differenzierung, was gefiltert wird (Blogs oder Workshops) hab ich die im Section-Element definierte Id ausgelesen -> evtl kann man dort das Ergebnis noch irgendwie zusammenfassen und muss nicht für jeden Seite eine Unterscheidung bilden

Allgemein müssen zu den Filter nicht mehr doppelt EventListener  hinzugefügt werden. Es reicht aus diese einmal der Map hinzuzufügen. Jeder Filter, der nicht auf der Seite existiert wirft eine Exception, die mit try/catch abgefangen wird.