### PR TITLE
Accessibility improvement

### DIFF
--- a/content/parents/dosanddonts/index.md
+++ b/content/parents/dosanddonts/index.md
@@ -3,9 +3,9 @@ title = "How to: Kind betreuen beim Workshop"
 image = "dosanddonts.png"
 +++
 
-{{< figure width="50%" src="dosanddonts.png" >}}
+{{< figure width="50%" src="dosanddonts.png" alt="Do’s and don’t’s" >}}
 
-Manchmal versuchst du deinem Kind etwas zu erklären, aber es läuft einfach nicht? Bei uns soll es um den Spaß an der Sache gehen. Deswegen ist auch wichtig, dass du als Elternteil dein Kind optimal unterstützt. 
+Manchmal versuchst du deinem Kind etwas zu erklären, aber es läuft einfach nicht? Bei uns soll es um den Spaß an der Sache gehen. Deswegen ist auch wichtig, dass du als Elternteil dein Kind optimal unterstützt.
 
 Berücksichtige dafür:
 

--- a/content/parents/dosanddonts/index.md
+++ b/content/parents/dosanddonts/index.md
@@ -3,7 +3,7 @@ title = "How to: Kind betreuen beim Workshop"
 image = "dosanddonts.png"
 +++
 
-{{< figure width="50%" src="dosanddonts.png" alt="Do’s and don’t’s" >}}
+{{< figure width="50%" src="dosanddonts.png" alt="Do's and don't's" >}}
 
 Manchmal versuchst du deinem Kind etwas zu erklären, aber es läuft einfach nicht? Bei uns soll es um den Spaß an der Sache gehen. Deswegen ist auch wichtig, dass du als Elternteil dein Kind optimal unterstützt.
 

--- a/themes/coderdojoschoeneweide/assets/scss/components/_team.scss
+++ b/themes/coderdojoschoeneweide/assets/scss/components/_team.scss
@@ -9,6 +9,11 @@
     color: $color-light;
   }
 
+  h3 {
+    text-align: center;
+    color: $color-light;
+  }
+  
   ul {
     list-style: none;
     margin: 0;

--- a/themes/coderdojoschoeneweide/layouts/_default/baseof.html
+++ b/themes/coderdojoschoeneweide/layouts/_default/baseof.html
@@ -1,46 +1,50 @@
 <!DOCTYPE html>
 <!--suppress HtmlUnknownTarget -->
 <html lang="{{.Site.LanguageCode}}">
-{{ block "head.html" . }}
+  {{ block "head.html" . }}
 
-<head>
-  <title>{{ block "title" .}}{{ .Site.Title }}{{ end }}</title>
+  <head>
+    <title>{{ block "title" .}}{{ .Site.Title }}{{ end }}</title>
 
-  <meta charset="utf-8" />
-  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-  {{ $scss := resources.Get "/scss/style.scss" }}
-  {{ $style := $scss | resources.ToCSS | resources.Minify | resources.Fingerprint }}
-  <link rel="stylesheet" type="text/css" href="{{ $style.RelPermalink }}" />
-  <script src="/js/obfuscate.js"></script>
-  <script src="/js/color-theme-switch.js"></script>
-</head>
-{{ end }}
-
-<body>
-  {{ block "header.html" . }}
-  <header class="site-header wrapper">
-    <label id="switch" class="switch">
-      <span style="visibility: hidden">theme</span>
-      <input type="checkbox" id="slider" title="theme" />
-      <span class="slider round"></span>
-    </label>
-    <a class="site-title site-title-light" href="/">
-      <img class="site-logo" src="/images/logo.webp" alt="CoderDojo Schoeneweide Logo" />
-    </a>
-
-    <a class="site-title site-title-dark" href="/">
-      <img class="site-logo" src="/images/logo_dark.webp" alt="CoderDojo Schoeneweide Logo" />
-    </a>
-
-    {{ partial "main-menu.html" (dict "page" .) }}
-  </header>
+    {{ $scss := resources.Get "/scss/style.scss" }}
+    {{ $style := $scss | resources.ToCSS | resources.Minify | resources.Fingerprint }}
+    <link rel="stylesheet" type="text/css" href="{{ $style.RelPermalink }}" />
+    <script src="/js/obfuscate.js"></script>
+    <script src="/js/color-theme-switch.js"></script>
+  </head>
   {{ end }}
 
-  <main id="content" class="wrapper columns" aria-label="Content">
-    {{ block "main" . }}{{ end }}
-  </main>
+  <body>
+    {{ block "header.html" . }}
+    <header class="site-header wrapper">
+      <label id="switch" class="switch">
+        <span style="visibility: hidden;">theme</span>
+        <input type="checkbox" id="slider" title="theme" />
+        <span class="slider round"></span>
+      </label>
+      <a class="site-title site-title-light" href="/">
+        <img
+          class="site-logo"
+          src="/images/logo.webp"
+          alt="CoderDojo Schoeneweide Logo"
+        />
+      </a>
+
+      <a class="site-title site-title-dark" href="/">
+        <img class="site-logo" src="/images/logo_dark.webp" alt="CoderDojo Schoeneweide Logo" />
+      </a>
+
+      {{ partial "main-menu.html" (dict "page" .) }}
+    </header>
+    {{ end }}
+
+    <main id="content" class="wrapper columns" aria-label="Content">
+      {{ block "main" . }}{{ end }}
+    </main>
 
     {{ block "footer.html" . }}
     <footer class="wrapper">

--- a/themes/coderdojoschoeneweide/layouts/_default/baseof.html
+++ b/themes/coderdojoschoeneweide/layouts/_default/baseof.html
@@ -18,7 +18,7 @@
   {{ end }}
   <body>
     {{ block "header.html" . }}
-    <header class="site-header wrapper" role="banner">
+    <header class="site-header wrapper">
       <label id="switch" class="switch">
         <span style="visibility: hidden">theme</span>
         <input type="checkbox" id="slider" />

--- a/themes/coderdojoschoeneweide/layouts/_default/baseof.html
+++ b/themes/coderdojoschoeneweide/layouts/_default/baseof.html
@@ -21,7 +21,7 @@
     <header class="site-header wrapper">
       <label id="switch" class="switch">
         <span style="visibility: hidden">theme</span>
-        <input type="checkbox" id="slider" />
+        <input type="checkbox" id="slider" title="theme" />
         <span class="slider round"></span>
       </label>
       <a class="site-title site-title-light" href="/">

--- a/themes/coderdojoschoeneweide/layouts/_default/baseof.html
+++ b/themes/coderdojoschoeneweide/layouts/_default/baseof.html
@@ -1,59 +1,60 @@
 <!DOCTYPE html>
 <!--suppress HtmlUnknownTarget -->
 <html lang="{{.Site.LanguageCode}}">
-{{ block "head.html" . }}
-<head>
+  {{ block "head.html" . }}
+  <head>
     <title>{{ block "title" .}}{{ .Site.Title }}{{ end }}</title>
 
-    <meta charset="utf-8"/>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
 
     {{ $scss := resources.Get "/scss/style.scss" }}
     {{ $style := $scss | resources.ToCSS | resources.Minify | resources.Fingerprint }}
-    <link rel="stylesheet" type="text/css" href="{{ $style.RelPermalink }}"/>
+    <link rel="stylesheet" type="text/css" href="{{ $style.RelPermalink }}" />
     <script src="/js/obfuscate.js"></script>
     <script src="/js/color-theme-switch.js"></script>
-</head>
-{{ end }}
-<body>
+  </head>
+  {{ end }}
+  <body>
     {{ block "header.html" . }}
     <header class="site-header wrapper" role="banner">
-        <label id="switch" class="switch">
-            <input type="checkbox" id="slider"/>
-            <span class="slider round"></span>
-        </label>
-        <a class="site-title site-title-light" href="/">
-            <img
-                    class="site-logo"
-                    src="/images/logo.webp"
-                    alt="CoderDojo Schoeneweide Logo"
-            />
-        </a>
+      <label id="switch" class="switch">
+        <span style="visibility: hidden">theme</span>
+        <input type="checkbox" id="slider" />
+        <span class="slider round"></span>
+      </label>
+      <a class="site-title site-title-light" href="/">
+        <img
+          class="site-logo"
+          src="/images/logo.webp"
+          alt="CoderDojo Schoeneweide Logo"
+        />
+      </a>
 
-        <a class="site-title site-title-dark" href="/">
-            <img
-                    class="site-logo"
-                    src="/images/logo_dark.webp"
-                    alt="CoderDojo Schoeneweide Logo"
-            />
-        </a>
+      <a class="site-title site-title-dark" href="/">
+        <img
+          class="site-logo"
+          src="/images/logo_dark.webp"
+          alt="CoderDojo Schoeneweide Logo"
+        />
+      </a>
 
-        {{ partial "main-menu.html" (dict "page" .) }}
+      {{ partial "main-menu.html" (dict "page" .) }}
     </header>
     {{ end }}
 
     <main id="content" class="wrapper columns" aria-label="Content">
-        {{ block "main" . }}{{ end }}
+      {{ block "main" . }}{{ end }}
     </main>
 
     {{ block "footer.html" . }}
     <footer class="wrapper">
-        {{ (.Site.GetPage "footer").Content }}
-        {{ partial "footer-menu.html" }}
+      {{ (.Site.GetPage "footer").Content }}
+      {{ partial "footer-menu.html" }}
     </footer>
     {{ end }}
     <script src="/js/filters.js"></script>
     <script src="/js/privacy-notice.js"></script>
-</body>
+  </body>
 </html>

--- a/themes/coderdojoschoeneweide/layouts/_default/baseof.html
+++ b/themes/coderdojoschoeneweide/layouts/_default/baseof.html
@@ -1,52 +1,46 @@
 <!DOCTYPE html>
 <!--suppress HtmlUnknownTarget -->
 <html lang="{{.Site.LanguageCode}}">
-  {{ block "head.html" . }}
-  <head>
-    <title>{{ block "title" .}}{{ .Site.Title }}{{ end }}</title>
+{{ block "head.html" . }}
 
-    <meta charset="utf-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+<head>
+  <title>{{ block "title" .}}{{ .Site.Title }}{{ end }}</title>
 
-    {{ $scss := resources.Get "/scss/style.scss" }}
-    {{ $style := $scss | resources.ToCSS | resources.Minify | resources.Fingerprint }}
-    <link rel="stylesheet" type="text/css" href="{{ $style.RelPermalink }}" />
-    <script src="/js/obfuscate.js"></script>
-    <script src="/js/color-theme-switch.js"></script>
-  </head>
+  <meta charset="utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+  {{ $scss := resources.Get "/scss/style.scss" }}
+  {{ $style := $scss | resources.ToCSS | resources.Minify | resources.Fingerprint }}
+  <link rel="stylesheet" type="text/css" href="{{ $style.RelPermalink }}" />
+  <script src="/js/obfuscate.js"></script>
+  <script src="/js/color-theme-switch.js"></script>
+</head>
+{{ end }}
+
+<body>
+  {{ block "header.html" . }}
+  <header class="site-header wrapper">
+    <label id="switch" class="switch">
+      <span style="visibility: hidden">theme</span>
+      <input type="checkbox" id="slider" title="theme" />
+      <span class="slider round"></span>
+    </label>
+    <a class="site-title site-title-light" href="/">
+      <img class="site-logo" src="/images/logo.webp" alt="CoderDojo Schoeneweide Logo" />
+    </a>
+
+    <a class="site-title site-title-dark" href="/">
+      <img class="site-logo" src="/images/logo_dark.webp" alt="CoderDojo Schoeneweide Logo" />
+    </a>
+
+    {{ partial "main-menu.html" (dict "page" .) }}
+  </header>
   {{ end }}
-  <body>
-    {{ block "header.html" . }}
-    <header class="site-header wrapper">
-      <label id="switch" class="switch">
-        <span style="visibility: hidden">theme</span>
-        <input type="checkbox" id="slider" title="theme" />
-        <span class="slider round"></span>
-      </label>
-      <a class="site-title site-title-light" href="/">
-        <img
-          class="site-logo"
-          src="/images/logo.webp"
-          alt="CoderDojo Schoeneweide Logo"
-        />
-      </a>
 
-      <a class="site-title site-title-dark" href="/">
-        <img
-          class="site-logo"
-          src="/images/logo_dark.webp"
-          alt="CoderDojo Schoeneweide Logo"
-        />
-      </a>
-
-      {{ partial "main-menu.html" (dict "page" .) }}
-    </header>
-    {{ end }}
-
-    <main id="content" class="wrapper columns" aria-label="Content">
-      {{ block "main" . }}{{ end }}
-    </main>
+  <main id="content" class="wrapper columns" aria-label="Content">
+    {{ block "main" . }}{{ end }}
+  </main>
 
     {{ block "footer.html" . }}
     <footer class="wrapper">

--- a/themes/coderdojoschoeneweide/layouts/index.html
+++ b/themes/coderdojoschoeneweide/layouts/index.html
@@ -24,7 +24,7 @@
 <section class="broad">
   {{ range where .Pages "Params.position" "broad" }}
   <section id="{{lower .File.BaseFileName}}">
-    <h2>{{ .Title }}</h2>
+    <h3>{{ .Title }}</h3>
     <p>{{ .Content }}</p>
     {{ if eq .Title "Team" }}
     <ul id="teamMemberList">

--- a/themes/coderdojoschoeneweide/layouts/index.html
+++ b/themes/coderdojoschoeneweide/layouts/index.html
@@ -1,44 +1,38 @@
-{{define "main"}}
-{{ with .Site.GetPage "/home" }}
+{{define "main"}} {{ with .Site.GetPage "/home" }}
 <section class="two-cols">
-    <main>
-        {{ range $index, $element := where .Pages "Params.position" "main" }}
-        <section id="{{ lower .File.BaseFileName }}">
-            {{ if eq $index 0 }}
-            <h1>{{ $element.Title }}</h1>
-            {{ else }}
-            <h2>{{ $element.Title }}</h2>
-            {{ end }}
-            <p> {{ $element.Content }}</p>
-        </section>
-        {{ end }}
-    </main>
-    <aside>
-        {{ range where .Pages "Params.position" "aside" }}
-        {{ $partialPath := printf "%s.html" (lower .Title) }}
-        {{ if templates.Exists ( printf "partials/%s" $partialPath ) }}
-        {{ partial $partialPath . }}
-        {{ else }}
-        <h2>{{ .Title }}</h2>
-        <p> {{ .Content }}</p>
-        {{ end }}
-        {{ end }}
-    </aside>
-</section>
-<section class="broad">
-    {{ range where .Pages "Params.position" "broad" }}
-    <section id="{{lower .File.BaseFileName}}">
-        <h2>{{ .Title }}</h2>
-        <p> {{ .Content }}</p>
-        {{ if eq .Title "Team" }}
-        <ul id="teamMemberList">
-            {{ range sort $.Site.Data.team "name" }}
-            {{ partial "team.html" . }}
-            {{ end }}
-        </ul>
-        {{ end }}
+  <div>
+    {{ range $index, $element := where .Pages "Params.position" "main" }}
+    <section id="{{ lower .File.BaseFileName }}">
+      {{ if eq $index 0 }}
+      <h1>{{ $element.Title }}</h1>
+      {{ else }}
+      <h2>{{ $element.Title }}</h2>
+      {{ end }}
+      <div>{{ $element.Content }}</div>
     </section>
     {{ end }}
+  </div>
+  <aside>
+    {{ range where .Pages "Params.position" "aside" }} {{ $partialPath := printf
+    "%s.html" (lower .Title) }} {{ if templates.Exists ( printf "partials/%s"
+    $partialPath ) }} {{ partial $partialPath . }} {{ else }}
+    <h2>{{ .Title }}</h2>
+    <div>{{ .Content }}</div>
+    {{ end }} {{ end }}
+  </aside>
 </section>
-{{ end }}
-{{ end }}
+<section class="broad">
+  {{ range where .Pages "Params.position" "broad" }}
+  <section id="{{lower .File.BaseFileName}}">
+    <h2>{{ .Title }}</h2>
+    <p>{{ .Content }}</p>
+    {{ if eq .Title "Team" }}
+    <ul id="teamMemberList">
+      {{ range sort $.Site.Data.team "name" }} {{ partial "team.html" . }} {{
+      end }}
+    </ul>
+    {{ end }}
+  </section>
+  {{ end }}
+</section>
+{{ end }} {{ end }}

--- a/themes/coderdojoschoeneweide/layouts/partials/contact.html
+++ b/themes/coderdojoschoeneweide/layouts/partials/contact.html
@@ -1,14 +1,12 @@
 <h2>Kontakt</h2>
 <ul class="social">
-    {{ range $.Site.Data.contact }}
-    {{ if ne .id "" }}
-    <li>
-        <a href="{{.href}}{{.id}}" target="_blank">
-            <svg viewBox="0 0 18 18">
-                <use xlink:href="/images/minima-social-icons.svg#{{.name}}"></use>
-            </svg>
-        </a>
-    </li>
-    {{ end }}
-    {{ end }}
+  {{ range $.Site.Data.contact }} {{ if ne .id "" }}
+  <li>
+    <a href="{{.href}}{{.id}}" target="_blank" title="{{.name}}">
+      <svg viewBox="0 0 18 18">
+        <use xlink:href="/images/minima-social-icons.svg#{{.name}}"></use>
+      </svg>
+    </a>
+  </li>
+  {{ end }} {{ end }}
 </ul>


### PR DESCRIPTION
TODOs:

Wave-Report:

- [x] Add a `title` attribute to the content element
- [x] Fix Empty form `label` of the theme switcher -> add hidden span with text (maybe there is a better solution here)
- [x] Add `alt` to "dosanddonts.png" image
- [x] Fix Team title Structural Elements -> use `h3` instead of `h2`

W3:

- [x] The `main` element must not appear as a descendant of the `section` element. -> use `div` instead
- [x]  No `p` element in scope but a `p` end tag seen. -> use `div` instead
- [x] The `banner` role is unnecessary for element `header`. -> remove `banner` attribute

Note:  Mehrere Tools schlugen vor, die Farben Orange und Weiß zu ändern, da sie nicht kontrastreich genug sind. Ich habe sie nicht geändert, weil ich das Brand-Design ändern wollte. :)

### Befor:

#### Wave
<img src="https://github.com/Coderdojo-Schoeneweide/website-hugo/assets/37506146/85d00b1c-8666-4aa9-b735-40b2d1c36210" width ="300"  >

#### Google lighthouse
<img src="https://github.com/Coderdojo-Schoeneweide/website-hugo/assets/37506146/ad160ad4-73a4-4413-b72d-b5249b566b9e" width ="300">

#### W3
<img src="https://github.com/Coderdojo-Schoeneweide/website-hugo/assets/37506146/b33d3a55-d837-4ceb-ad12-70ccafbf290f" width ="300">



### After: 

#### Wave

<img src="https://github.com/Coderdojo-Schoeneweide/website-hugo/assets/37506146/5bb3d4a8-3cc7-42fc-bc70-972cde973430" width ="300"  >

#### Google lighthouse
<img src="https://github.com/Coderdojo-Schoeneweide/website-hugo/assets/37506146/84c238f2-e79d-4389-854d-00c7b3e2db5b" width ="300">


#### W3
<img src="https://github.com/Coderdojo-Schoeneweide/website-hugo/assets/37506146/ece026db-85ac-45c7-8ecc-7c29146fd389" width ="300">


