### PR TITLE
Seo optimisierung canonical link

### DIFF
--- a/themes/coderdojoschoeneweide/layouts/_default/baseof.html
+++ b/themes/coderdojoschoeneweide/layouts/_default/baseof.html
@@ -13,6 +13,7 @@
 	<meta name="keywords" content="CoderDojo Oberschöneweide, Programmieren für Kinder, kostenlose Workshops, Coden lernen, digitale Kompetenz, kreative Computer-Nutzung, Projektbasiertes Lernen, kostenlos, Treptow-Köpenick, Berlin" />
     {{ $scss := resources.Get "/scss/style.scss" }}
     {{ $style := $scss | resources.ToCSS | resources.Minify | resources.Fingerprint }}
+	<link rel="canonical" href="{{ .Permalink }}" />
     <link rel="stylesheet" type="text/css" href="{{ $style.RelPermalink }}" />
     <script src="/js/obfuscate.js"></script>
     <script src="/js/color-theme-switch.js"></script>


### PR DESCRIPTION
`canonical` link ergänzt. Der sollte m.E. auf den FQDN verweisen. In der lokalen Hugo-Instanz verweist er auf `localhost:1313`